### PR TITLE
Added the Hotfix for the Mitre Group Alias

### DIFF
--- a/yara-validator/yara_validator.py
+++ b/yara-validator/yara_validator.py
@@ -480,9 +480,16 @@ class YaraValidator:
                 if not self.required_fields[key].found:
                     keys_to_return.append(key)
 
-        if self.mitre_group_alias and self.required_fields[ACTOR].found:
-            keys_to_return.append(self.required_fields[ACTOR].argument.get("child_place_holder"))
-        return keys_to_return
+            if self.__mitre_group_alias() and self.required_fields[ACTOR].found:
+                keys_to_return.append(self.required_fields[ACTOR].argument.get("child_place_holder"))
+            return keys_to_return
+
+    def __mitre_group_alias(self):
+        """
+        Private function to return the value of mitre_group_alias which would be set if any actor value was found
+        :return: the value of the validators.mitre_group_alias variable
+        """
+        return self.validators.mitre_group_alias
 
     def __parse_scheme(self, cfg_to_parse):
         cfg_being_parsed = ""


### PR DESCRIPTION
- added __mitre_group_alias to pull the value of mitre_group_alias from the self.validators object
- changed the check in return_req_optional function to reference self.__mitre_group_alias instead of self.mitre_group_alias which remains None

This commit it so that the mitre_group_generator function gets called when an actor is present.