### PR TITLE
Feature standardizelinesstartcharacters

### DIFF
--- a/CCCS_YARA.yml
+++ b/CCCS_YARA.yml
@@ -95,7 +95,7 @@ version:
    optional: Optional
    validator: valid_version
 
-minimum_yara:
+yara_version:
    description: 'Minimum version of Yara to run the rule'
    format: 'x.x'
    unique: Yes

--- a/yara-validator/validator_cfg.yml
+++ b/yara-validator/validator_cfg.yml
@@ -6,8 +6,6 @@
 #    description: <description of the setting>
 #    value: <value of the setting>
 #
-# --NOTE--
-# 1. Currently only one setting to set the default behavior
 #
 
 ---
@@ -18,3 +16,11 @@ string_encoding:
                     utf-8:  Will check if the file contains only UTF-8 characters
                     none:   Will perform no check'
    value: utf-8
+
+white_space_replacement:
+   description: 'Used to set the white space which will be searched for, what it will be replaced with and how many
+                 of those characters will be used'
+   value:
+      char_to_replace: '\t'
+      char_replacement: ' '
+      count_of_replaced: 4

--- a/yara-validator/yara_file_processor.py
+++ b/yara-validator/yara_file_processor.py
@@ -81,6 +81,14 @@ class YaraFileProcessor:
                 yara_rule = YaraRule(string_of_rule, plyara_rule)
                 self.yara_rules.append(yara_rule)
 
+    def __standardize_white_space(self, edited_rule_string):
+        """
+        Takes the edited_rule_string, scans the start of each line for the self.char_to_replace and replaces each with
+
+        :param edited_rule_string:
+        :return:
+        """
+
     def strings_of_rules_to_original_file(self):
         """
         This rebuilds a rule string incorporating any changes from the rule return objects
@@ -98,6 +106,7 @@ class YaraFileProcessor:
                 edited_rule_string = edited_rule_string[0:rule.rule_plyara['start_line'] - 1]\
                                      + changed_rule_string + edited_rule_string[rule.rule_plyara['stop_line']:]
 
+        self.__standardize_white_space(edited_rule_string)
         edited_rule_string = '\n'.join(edited_rule_string)
         self.edited_rule_string = edited_rule_string
 


### PR DESCRIPTION
White space standardization and change to minimum_yara

Added the feature to standardize the leading white space in validated yara files. This is configured in the validator_cfg.yml file using its three values: char_to_replace, char_replacement and count_of_replaced.
- char_to_replace is the white space character you want to replace, default '\t'
- char_replacement is the white space character you want it replaced with, default ' '
- count_of_replaced is the number of char_replacement characters you want to use in the replacement, default 4

minimum_yara was changed to yara_version for compatibility reasons