### PR TITLE
Bugfix

### DIFF
--- a/yara-validator/yara_file_processor.py
+++ b/yara-validator/yara_file_processor.py
@@ -149,6 +149,8 @@ class YaraFileProcessor:
                 non_white_space_index = index
                 break
 
+        if non_white_space_index == 0:
+            non_white_space_index = len(line_as_list)
         new_list = new_list + line_as_list[non_white_space_index:]
 
         newline = ''.join(new_list)


### PR DESCRIPTION
- YaraFileProcessor.__replace_for_each_one_to_many() did not handle lines with only spaces or tabs well. Since the non_white_space_index only got set higher then 0 if a non_white_space character
was found likes without spaces or tabs would double in size.
- Added a check, if non_white_space_index == 0 then set it to the lenghth of the line.