### PR TITLE
Remove global Regex flags from allowed values

### DIFF
--- a/CCCS_YARA_values.yml
+++ b/CCCS_YARA_values.yml
@@ -143,11 +143,11 @@ actor_types:
 
 hash_types:
    -
-      value: "(?i)[a-f0-9]{32}"
+      value: "[a-fA-F0-9]{32}"
    -
-      value: "(?i)[a-f0-9]{40}"
+      value: "[a-fA-F0-9]{40}"
    -
-      value: "(?i)[a-f0-9]{64}"
+      value: "[a-fA-F0-9]{64}"
 
 unvalidated_regex:
    -


### PR DESCRIPTION
The global regex flags, while allowed per-regex, are required to be at the start of a regex expression. The current code joins regular extressions resulting in an exception being generated as the global flags get nested within the expression itself. To avoid this issue, the global case-insensitive flags can be ommited and instead specify the case-sensitive equivalence.

As an example, the following exception gets raised as the invalid `'^(?i)[a-f0-9]{32}$|^(?i)[a-f0-9]{40}$|^(?i)[a-f0-9]{64}$'` expression gets evaluated:
```
Traceback (most recent call last):
  File "CCCS-Yara\yara-validator\yara_validator.py", line 135, in run_yara_validator
    rule.add_rule_return(validator.validation(rule.rule_plyara, rule.rule_string, generate_values))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "CCCS-Yara\yara-validator\yara_validator.py", line 502, in validation
    validity, rule_response = self.process_key(key, self.required_fields, rule_to_validate,
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "CCCS-Yara\yara-validator\yara_validator.py", line 465, in process_key
    if not fields[key].function(rule_processing_key, metadata_index, key):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "CCCS-Yara\yara-validator\validator_functions.py", line 125, in valid_regex
    if re.fullmatch(regex_expression, value):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.11_3.11.1008.0_x64__qbz5n2kfra8p0\Lib\re\__init__.py", line 171, in fullmatch
    return _compile(pattern, flags).fullmatch(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.11_3.11.1008.0_x64__qbz5n2kfra8p0\Lib\re\__init__.py", line 294, in _compile
    p = _compiler.compile(pattern, flags)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.11_3.11.1008.0_x64__qbz5n2kfra8p0\Lib\re\_compiler.py", line 743, in compile
    p = _parser.parse(p, flags)
        ^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.11_3.11.1008.0_x64__qbz5n2kfra8p0\Lib\re\_parser.py", line 980, in parse
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.11_3.11.1008.0_x64__qbz5n2kfra8p0\Lib\re\_parser.py", line 455, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.11_3.11.1008.0_x64__qbz5n2kfra8p0\Lib\re\_parser.py", line 841, in _parse
    raise source.error('global flags not at the start '
re.error: global flags not at the start of the expression at position 1

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "CCCS-Yara\yara_validator_cli.py", line 311, in <module>
    main()
  File "CCCS-Yara\yara_validator_cli.py", line 307, in main
    __call_validator(options)
  File "CCCS-Yara\yara_validator_cli.py", line 198, in __call_validator
    yara_file_processor = run_yara_validator(yara_rule_path, generate_values, options.module)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "CCCS-Yara\yara-validator\yara_validator.py", line 137, in run_yara_validator
    raise Exception(
Exception: rule produced the following exception: global flags not at the start of the expression at position 1. Halting validation..
```