### PR TITLE
fix typo in validator_functions.py

### DIFF
--- a/yara_validator/validator_functions.py
+++ b/yara_validator/validator_functions.py
@@ -321,7 +321,7 @@ class Validators:
                     # Date isn't in the expected format, let's see if we can convert it
                     success, formatted_date = convert_date(date)
                     if success and Helper.validate_date(formatted_date):
-                        self.required_fields[DATE].attibutevalid()
+                        self.required_fields[DATE].attributevalid()
                         update_metadata(date, force=True)
                     else:
                         self.required_fields[DATE].attributeinvalid()


### PR DESCRIPTION
Theres a typo and when launching it plain per CLI.

I guess that it this should have ment attributevalid()
Since it throws an error while running directly the yara_validator against a bunch of files (-c) :
yara_validator\validator_functions.py", line 324, in valid_date self.required_fields[DATE].attibutevalid() AttributeError: 'MetadataAttributes' object has no attribute 'attibutevalid'. Did you mean: 'attributevalid'?

Or maybe I'm completely wrong here and it was intended - it fixed my issue at least :)
@cccs-rs