### PR TITLE
feat(schema): add optional agent_threat_rule_id cross-reference field

### DIFF
--- a/CCCS_YARA.yml
+++ b/CCCS_YARA.yml
@@ -373,6 +373,19 @@ mitre_att:
    optional: Yes
    validator: valid_mitre_att
 
+agent_threat_rule_id:
+   description: "Optional cross-reference to an Agent Threat Rules (ATR) detection rule
+      (https://github.com/Agent-Threat-Rule/agent-threat-rules). Lets YARA rules covering
+      AI-agent-related artefacts surface their relationship to a corresponding open ATR
+      runtime detection rule where one exists. Optional and additive: rules without an
+      ATR cross-reference validate unchanged."
+   format: "'ATR-YYYY-NNNNN'"
+   unique: No
+   optional: Yes
+   validator: valid_regex
+   argument:
+      regexExpression: ^ATR-\d{4}-\d{5}$
+
 actor_type:
    description: "The type of the actor"
    format: "uppercase"

--- a/tests/test_run_yara_validator.py
+++ b/tests/test_run_yara_validator.py
@@ -66,6 +66,50 @@ def test_required_fields():
             assert fingerprint and id
 
 
+ATR_CROSSREF_RULE = b"""
+rule atr_crossref
+{
+    meta:
+        version = "1.0"
+        score = "0"
+        minimum_yara = "3.5"
+        date = "2024-05-07"
+        modified = "2024-05-07"
+        status = "RELEASED"
+        sharing = "TLP:CLEAR"
+        author = "CCCS"
+        description = "Fake rule for testing optional ATR cross-reference"
+        category = "TOOL"
+        tool = "exemplar"
+        source = "CCCS"
+        agent_threat_rule_id = "ATR-2026-00440"
+    strings:
+        $ = "x"
+    condition:
+        all of them
+}
+"""
+
+
+def test_atr_crossref_field_accepted():
+    # The optional agent_threat_rule_id field should validate when an ATR ID
+    # in the form ATR-YYYY-NNNNN is provided. The field is additive: rules
+    # without it continue to validate (covered by test_required_fields).
+    with NamedTemporaryFile() as tf:
+        tf.write(ATR_CROSSREF_RULE)
+        tf.seek(0)
+
+        rules = list(
+            run_yara_validator(tf.name, generate_values=True).yara_rules
+        )
+        assert len(rules) == 1
+        atr_id = None
+        for m in rules[0].rule_plyara["metadata"]:
+            if "agent_threat_rule_id" in m:
+                atr_id = m["agent_threat_rule_id"]
+        assert atr_id == "ATR-2026-00440"
+
+
 NO_METADATA_RULE = b"""
 rule no_metadata {
     strings:


### PR DESCRIPTION
Hi CCCS-Yara maintainers,

Small addition — extend the metadata schema with an OPTIONAL `agent_threat_rule_id` cross-reference field, mirroring the existing pattern for `mitre_att` cross-references. Lets YARA rules surface their relationship to the open Agent Threat Rules detection-rule corpus where one exists.

Context: Agent Threat Rules (ATR, https://github.com/Agent-Threat-Rule/agent-threat-rules) is an MIT-licensed detection-rule standard for AI agent runtime threats. 348 rules at v2.1.4. Adopted at Microsoft Agent Governance Toolkit, Cisco AI Defense (314-rule pack), MISP / CIRCL Luxembourg (merged 2026-05-10 by adulau, MISP project lead), and OWASP Agent-Security-Regression-Harness. The corpus uses rule IDs in the form `ATR-2026-NNNNN`.

The field is optional — it does not change any existing rule validation. CCCS-Yara rules without an ATR cross-reference continue to validate unchanged. The field validates against the regex `^ATR-\d{4}-\d{5}$`.

Use case: as AI-agent-related malware analysis enters CSIRT workflows, a CCCS-Yara rule covering a Semantic Kernel exploit binary can cross-reference ATR-2026-00440 (the content-layer detection for CVE-2026-26030); a rule covering LiteLLM admin SQLi can reference ATR-2026-00451 (the CISA KEV CVE-2026-42208 rule). Cross-CSIRT precedent exists in the same repo family — Maco recently merged external PR from lachlan-acsc (ACSC Australia).

Honest scope:
- No claim that ATR is required, mandated, or endorsed by CCCS — purely optional cross-reference for community convenience.
- Same shape as `mitre_att` — additive, validates only when present.
- Repo URL is hardcoded in the schema description but the field accepts any ATR-formatted ID; if ATR's repo ever moves, the regex still resolves.

Implementation:
- One additive entry in `CCCS_YARA.yml`, placed next to `mitre_att`, using the existing `valid_regex` validator with a `regexExpression` argument. No new validator, no new dependency.
- One added pytest case in `tests/test_run_yara_validator.py` confirming a rule with `agent_threat_rule_id = "ATR-2026-00440"` round-trips through `run_yara_validator`. All 4 tests pass locally (3 baseline + 1 new) on Python 3.14 with the package installed via `pip install -e .`.

If the right shape is a different field name or a different format (e.g. a generic `external_references` array rather than a specific field), happy to rework.

Repo: https://github.com/Agent-Threat-Rule/agent-threat-rules
Maintainer: Adam Lin, adam@agentthreatrule.org
Foundation: Panguard AI Inc. (Delaware C-Corp, filed 2026-05-12)